### PR TITLE
fix: 🐛 Fixed the data range for x axis in regression plot

### DIFF
--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,8 +1,21 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
+  "Serilog": {
+    "MinimumLevel": "Information",
+    "Override": {
       "Microsoft.AspNetCore": "Warning"
-    }
-  }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "/var/logs/egal-api/egal-api-logs.log",
+          "rollingInterval": "Day"
+        }
+      }
+    ]
+  },
+  "Urls": "https://*:7373;http://*:7374"
 }

--- a/linear_regression/regression_plot.py
+++ b/linear_regression/regression_plot.py
@@ -11,7 +11,7 @@ def plot_regression_graph(url):
     train_features, training_labels = lr.get_training_sets(url)
     x_dimension_trained_model = lr.linear_regression_model(url)
 
-    x = cl.np.array(cl.tf.linspace(0.0, 100, 101))
+    x = cl.np.array(train_features['x'][:500])
     y = cl.np.array(x_dimension_trained_model.predict(x)).reshape(-1)
 
     fig = cl.plt.figure()


### PR DESCRIPTION
Fix for the data range in X axis. Earlier on it was hard coded to plot the graph from 0 to 100. But datasets can be of varying amounts. 